### PR TITLE
Fix center calculation in sh/tools/dcolors

### DIFF
--- a/sh/tools/dcolors
+++ b/sh/tools/dcolors
@@ -57,8 +57,8 @@ _kmeans_awk() {
     }
 
     function _calculate_center(plist) {
-        plist_array_len=split(plist, plist_array)
-        sumX=0; sumY=0; sumZ=0;
+        split(plist, plist_array)
+        count=0; sumX=0; sumY=0; sumZ=0;
         for (point in plist_array) {
             split(plist_array[point], coordinates, ",")
             for (coordinate in coordinates) {
@@ -66,6 +66,7 @@ _kmeans_awk() {
                     split(coordinates[coordinate], composed_coordinate, ":")
                     times=composed_coordinate[1]
                     coordinateX=composed_coordinate[2]
+                    count+=times
                     sumX+=coordinateX*times
                 }
                 else if (coordinate == 2) sumY+=coordinates[coordinate] * times
@@ -74,10 +75,10 @@ _kmeans_awk() {
         }
 
         //avoid division by zero
-        if(plist_array_len) {
-            sumX=int(sumX/plist_array_len)
-            sumY=int(sumY/plist_array_len)
-            sumZ=int(sumZ/plist_array_len)
+        if(count) {
+            sumX=int(sumX/count)
+            sumY=int(sumY/count)
+            sumZ=int(sumZ/count)
         }
         return sumX "," sumY "," sumZ
     }


### PR DESCRIPTION
First, thank you for your ```dcolors``` script.

On this picture
![skullInsideYourFace](https://user-images.githubusercontent.com/5408235/105737937-cb61f780-5f36-11eb-8c60-0dfe41d11adc.jpg)
the command ```./dcolors -k1 skullInsideYourFace.jpg``` resulted in ```100,163,299``` which blue value is beyond 255 and thus is an invalid color. After some debugging, I've found out, thet the center point calculation doesn't calculate for color times.

After this fix, the result is [```34,57,104```](https://color-hex.org/color/223968).

